### PR TITLE
Bump starlette 1.2.1 → 1.3.1 (Dependabot high + low)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -806,15 +806,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.2.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bumps **starlette** `1.2.1 → 1.3.1` to clear two Dependabot advisories. Starlette is a transitive dependency via **fastapi** (the optional `[ui]` extra), so only the pin in `uv.lock` changes.

| Severity | Advisory | Issue | Fixed in |
|---|---|---|---|
| **High** | GHSA-82w8-qh3p-5jfq | `request.form()` size limits silently ignored for `application/x-www-form-urlencoded` → DoS | 1.3.1 |
| Low | GHSA-jp82-jpqv-5vv3 | Unvalidated request path concatenated into the authority poisons `request.url.hostname` | 1.3.0 |

`1.3.1` covers both.

## Verification

- `fastapi` 0.136.3 resolves cleanly on starlette 1.3.1; **only `uv.lock` changed**
- `uv run pytest` → **481 passed** (14 live deselected)
- UI suite (FastAPI TestClient, the code path that exercises starlette) → **41 passed**
- Live UI boot OK: `GET /` and `/healthz` → 200
- `ruff check` clean
- Bundled skill is CLI-only (no `[ui]` deps) → no regen needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)